### PR TITLE
Set content-type to text/html in pretty page handler

### DIFF
--- a/handler/PrettyPageHandler.js
+++ b/handler/PrettyPageHandler.js
@@ -144,6 +144,7 @@ PrettyPageHandler.prototype.handle = function (next) {
 
     if (this.__response && this.__sendResponse) {
         if (!this.__response.headersSent) {
+            this.__response.setHeader('Content-Type: text/html');
             this.__response.writeHead(code);
         }
 


### PR DESCRIPTION
Otherwise Safari will download page and Chrome will just display it as text.