### PR TITLE
Add additional Node versions to travis.yml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 4
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,5 @@ node_js:
     - "0.12"
     - "4"
     - "5"
-    - "6"
-    - "7"
-    - "8"
 before_install:
     - "npm config set strict-ssl false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
+    - "4"
+    - "5"
+    - "6"
+    - "7"
+    - "8"
 before_install:
     - "npm config set strict-ssl false"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ node_js:
     - "8"
 before_install:
     - "npm config set strict-ssl false"
-

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/quorrajs/Ouch/issues"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.10.0 <6.0"
   },
   "dependencies": {
     "ejs": "^2.3.1",


### PR DESCRIPTION
- Updates travis.yml to include additional node versions (node 5 + 6)
- Updates package.json engines property to indicate that this package is intended for node versions < 6 as the test suite will not pass past node v5.x
- Adds .editorconfig to keeps indentation style consistent between authors and editors