### PR TITLE
Update ejs to 3.1.7 to patch against CVE-2022-29078

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@positron/stack-trace": "1.0.0",
-    "ejs": "^2.3.1",
+    "ejs": "^3.1.7",
     "escape-html": "^1.0.1",
     "lodash": "^4.17.10"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ouch",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Javascript error handling for cool kids",
   "main": "Ouch.js",
   "scripts": {


### PR DESCRIPTION
All test are passing.

An update on mocha is also needed, I tried to just update it but tests failed so it needs more work for the latest mocha version.